### PR TITLE
Fix the render using the selective re-rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.2.0",
     "@popperjs/core": "^2.11.8",
-    "@videosdk.live/react-sdk": "^0.4.8",
+    "@videosdk.live/react-sdk": "^0.8.2",
     "lottie-react": "^2.4.1",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-loader": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.2.0",
     "@popperjs/core": "^2.11.8",
-    "@videosdk.live/react-sdk": "^0.8.2",
+    "@videosdk.live/react-sdk": "^0.9.0",
     "lottie-react": "^2.4.1",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-loader": "^8.1.1",

--- a/src/components/ParticipantView.js
+++ b/src/components/ParticipantView.js
@@ -12,15 +12,40 @@ import SpeakerIcon from "../icons/SpeakerIcon";
 import { getQualityScore, nameTructed } from "../utils/common";
 import * as ReactDOM from "react-dom";
 import { useMeetingAppContext } from "../MeetingAppContextDef";
-export const CornerDisplayName = ({
-  participantId,
-  isPresenting,
-  displayName,
-  isLocal,
-  micOn,
-  mouseOver,
-  isActiveSpeaker,
-}) => {
+
+const CornerDisplayInfo = ({ participantId, isPresenting, show }) => {
+  const { displayName, isLocal, micOn, isActiveSpeaker } =
+    useParticipant(participantId);
+
+  return (
+    <div
+      className="absolute bottom-2 left-2 rounded-md flex items-center justify-center p-2"
+      style={{
+        backgroundColor: "#00000066",
+        transition: "all 200ms",
+        transitionTimingFunction: "linear",
+        transform: `scale(${show ? 1 : 0})`,
+      }}
+    >
+      {!micOn && !isPresenting ? (
+        <MicOffSmallIcon fillcolor="white" />
+      ) : micOn && isActiveSpeaker ? (
+        <SpeakerIcon />
+      ) : null}
+      <p className="text-sm text-white ml-0.5">
+        {isPresenting
+          ? isLocal
+            ? `You are presenting`
+            : `${nameTructed(displayName, 15)} is presenting`
+          : isLocal
+            ? "You"
+            : nameTructed(displayName, 26)}
+      </p>
+    </div>
+  );
+};
+
+const CornerDisplayStats = ({ participantId, isPresenting }) => {
   const isMobile = useIsMobile();
   const isTab = useIsTab();
   const isLGDesktop = useMediaQuery({ minWidth: 1024, maxWidth: 1439 });
@@ -31,7 +56,7 @@ export const CornerDisplayName = ({
   const [statsBoxHeightRef, setStatsBoxHeightRef] = useState(null);
   const [statsBoxWidthRef, setStatsBoxWidthRef] = useState(null);
 
-  const [coords, setCoords] = useState({}); // takes current button coordinates
+  const [coords, setCoords] = useState({});
 
   const statsBoxHeight = useMemo(
     () => statsBoxHeightRef?.offsetHeight,
@@ -53,9 +78,8 @@ export const CornerDisplayName = ({
           ? 20
           : 18;
 
-  const show = useMemo(() => mouseOver, [mouseOver]);
-
   const {
+    isLocal,
     webcamStream,
     micStream,
     screenShareStream,
@@ -76,7 +100,6 @@ export const CornerDisplayName = ({
     let videoStats = [];
     if (isPresenting) {
       stats = await getShareStats();
-
     } else if (webcamStream) {
       stats = await getVideoStats();
     } else if (micStream) {
@@ -216,211 +239,196 @@ export const CornerDisplayName = ({
     };
   }, [webcamStream, micStream, screenShareStream]);
 
+  if (!(webcamStream || micStream || screenShareStream)) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        className="absolute top-2 right-2 rounded-md  p-2 cursor-pointer "
+      >
+        <Popover className="relative ">
+          {({ close }) => (
+            <>
+              <Popover.Button
+                className={`absolute right-0 top-0 rounded-md flex items-center justify-center p-1.5 cursor-pointer`}
+                style={{
+                  backgroundColor:
+                    score > 7
+                      ? "#3BA55D"
+                      : score > 4
+                        ? "#faa713"
+                        : "#FF5D5D",
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const rect = e.target.getBoundingClientRect();
+                  setCoords({
+                    left: Math.round(rect.x + rect.width / 2),
+                    top: Math.round(rect.y + window.scrollY),
+                  });
+                }}
+              >
+                <div>
+                  <NetworkIcon
+                    color1={"#ffffff"}
+                    color2={"#ffffff"}
+                    color3={"#ffffff"}
+                    color4={"#ffffff"}
+                    style={{
+                      height: analyzerSize * 0.6,
+                      width: analyzerSize * 0.6,
+                    }}
+                  />
+                </div>
+              </Popover.Button>
+              <Transition
+                as={Fragment}
+                enter="transition ease-out duration-200"
+                enterFrom="opacity-0 translate-y-1"
+                enterTo="opacity-100 translate-y-0"
+                leave="transition ease-in duration-150"
+                leaveFrom="opacity-100 translate-y-0"
+                leaveTo="opacity-0 translate-y-1"
+              >
+                <Popover.Panel style={{ zIndex: 999 }} className="absolute">
+                  {ReactDOM.createPortal(
+                    <div
+                      ref={setStatsBoxWidthRef}
+                      style={{
+                        top:
+                          coords?.top + statsBoxHeight > windowHeight
+                            ? windowHeight - statsBoxHeight - 20
+                            : coords?.top,
+                        left:
+                          coords?.left - statsBoxWidth < 0
+                            ? 12
+                            : coords?.left - statsBoxWidth,
+                      }}
+                      className={`absolute`}
+                    >
+                      <div
+                        ref={setStatsBoxHeightRef}
+                        className="bg-gray-800 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 "
+                      >
+                        <div
+                          className={`p-[9px] flex items-center justify-between rounded-t-lg`}
+                          style={{
+                            backgroundColor:
+                              score > 7
+                                ? "#3BA55D"
+                                : score > 4
+                                  ? "#faa713"
+                                  : "#FF5D5D",
+                          }}
+                        >
+                          <p className="text-sm text-white font-semibold">{`Quality Score : ${score > 7
+                              ? "Good"
+                              : score > 4
+                                ? "Average"
+                                : "Poor"
+                            }`}</p>
+
+                          <button
+                            className="cursor-pointer text-white hover:bg-[#ffffff33] rounded-full px-1 text-center"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              close();
+                            }}
+                          >
+                            <XMarkIcon
+                              className="text-white"
+                              style={{ height: 16, width: 16 }}
+                            />
+                          </button>
+                        </div>
+                        <div className="flex">
+                          <div className="flex flex-col">
+                            {qualityStateArray.map((item, index) => {
+                              return (
+                                <div
+                                  className="flex"
+                                  style={{
+                                    borderBottom:
+                                      index === qualityStateArray.length - 1
+                                        ? ""
+                                        : `1px solid #ffffff33`,
+                                  }}
+                                >
+                                  <div className="flex flex-1 items-center w-[120px]">
+                                    {index !== 0 && (
+                                      <p className="text-xs text-white my-[6px] ml-2">
+                                        {item.label}
+                                      </p>
+                                    )}
+                                  </div>
+                                  <div
+                                    className="flex flex-1 items-center justify-center"
+                                    style={{
+                                      borderLeft: `1px solid #ffffff33`,
+                                    }}
+                                  >
+                                    <p className="text-xs text-white my-[6px] w-[80px] text-center">
+                                      {item.audio}
+                                    </p>
+                                  </div>
+                                  <div
+                                    className="flex flex-1 items-center justify-center"
+                                    style={{
+                                      borderLeft: `1px solid #ffffff33`,
+                                    }}
+                                  >
+                                    <p className="text-xs text-white my-[6px] w-[80px] text-center">
+                                      {item.video}
+                                    </p>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      </div>
+                    </div>,
+                    document.body
+                  )}
+                </Popover.Panel>
+              </Transition>
+            </>
+          )}
+        </Popover>
+      </div>
+    </div>
+  );
+};
+
+export const CornerDisplayName = ({
+  participantId,
+  isPresenting,
+  mouseOver,
+}) => {
   return (
     <>
-      <div
-        className="absolute bottom-2 left-2 rounded-md flex items-center justify-center p-2"
-        style={{
-          backgroundColor: "#00000066",
-          transition: "all 200ms",
-          transitionTimingFunction: "linear",
-          transform: `scale(${show ? 1 : 0})`,
-        }}
-      >
-        {!micOn && !isPresenting ? (
-          <MicOffSmallIcon fillcolor="white" />
-        ) : micOn && isActiveSpeaker ? (
-          <SpeakerIcon />
-        ) : null}
-        <p className="text-sm text-white ml-0.5">
-          {isPresenting
-            ? isLocal
-              ? `You are presenting`
-              : `${nameTructed(displayName, 15)} is presenting`
-            : isLocal
-              ? "You"
-              : nameTructed(displayName, 26)}
-        </p>
-      </div>
-
-      {(webcamStream || micStream || screenShareStream) && (
-        <div>
-          <div
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
-            className="absolute top-2 right-2 rounded-md  p-2 cursor-pointer "
-          >
-            <Popover className="relative ">
-              {({ close }) => (
-                <>
-                  <Popover.Button
-                    className={`absolute right-0 top-0 rounded-md flex items-center justify-center p-1.5 cursor-pointer`}
-                    style={{
-                      backgroundColor:
-                        score > 7
-                          ? "#3BA55D"
-                          : score > 4
-                            ? "#faa713"
-                            : "#FF5D5D",
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      const rect = e.target.getBoundingClientRect();
-                      setCoords({
-                        left: Math.round(rect.x + rect.width / 2),
-                        top: Math.round(rect.y + window.scrollY),
-                      });
-                    }}
-                  >
-                    <div>
-                      <NetworkIcon
-                        color1={"#ffffff"}
-                        color2={"#ffffff"}
-                        color3={"#ffffff"}
-                        color4={"#ffffff"}
-                        style={{
-                          height: analyzerSize * 0.6,
-                          width: analyzerSize * 0.6,
-                        }}
-                      />
-                    </div>
-                  </Popover.Button>
-                  <Transition
-                    as={Fragment}
-                    enter="transition ease-out duration-200"
-                    enterFrom="opacity-0 translate-y-1"
-                    enterTo="opacity-100 translate-y-0"
-                    leave="transition ease-in duration-150"
-                    leaveFrom="opacity-100 translate-y-0"
-                    leaveTo="opacity-0 translate-y-1"
-                  >
-                    <Popover.Panel style={{ zIndex: 999 }} className="absolute">
-                      {ReactDOM.createPortal(
-                        <div
-                          ref={setStatsBoxWidthRef}
-                          style={{
-                            top:
-                              coords?.top + statsBoxHeight > windowHeight
-                                ? windowHeight - statsBoxHeight - 20
-                                : coords?.top,
-                            left:
-                              coords?.left - statsBoxWidth < 0
-                                ? 12
-                                : coords?.left - statsBoxWidth,
-                          }}
-                          className={`absolute`}
-                        >
-                          <div
-                            ref={setStatsBoxHeightRef}
-                            className="bg-gray-800 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 "
-                          >
-                            <div
-                              className={`p-[9px] flex items-center justify-between rounded-t-lg`}
-                              style={{
-                                backgroundColor:
-                                  score > 7
-                                    ? "#3BA55D"
-                                    : score > 4
-                                      ? "#faa713"
-                                      : "#FF5D5D",
-                              }}
-                            >
-                              <p className="text-sm text-white font-semibold">{`Quality Score : ${score > 7
-                                  ? "Good"
-                                  : score > 4
-                                    ? "Average"
-                                    : "Poor"
-                                }`}</p>
-
-                              <button
-                                className="cursor-pointer text-white hover:bg-[#ffffff33] rounded-full px-1 text-center"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  close();
-                                }}
-                              >
-                                <XMarkIcon
-                                  className="text-white"
-                                  style={{ height: 16, width: 16 }}
-                                />
-                              </button>
-                            </div>
-                            <div className="flex">
-                              <div className="flex flex-col">
-                                {qualityStateArray.map((item, index) => {
-                                  return (
-                                    <div
-                                      className="flex"
-                                      style={{
-                                        borderBottom:
-                                          index === qualityStateArray.length - 1
-                                            ? ""
-                                            : `1px solid #ffffff33`,
-                                      }}
-                                    >
-                                      <div className="flex flex-1 items-center w-[120px]">
-                                        {index !== 0 && (
-                                          <p className="text-xs text-white my-[6px] ml-2">
-                                            {item.label}
-                                          </p>
-                                        )}
-                                      </div>
-                                      <div
-                                        className="flex flex-1 items-center justify-center"
-                                        style={{
-                                          borderLeft: `1px solid #ffffff33`,
-                                        }}
-                                      >
-                                        <p className="text-xs text-white my-[6px] w-[80px] text-center">
-                                          {item.audio}
-                                        </p>
-                                      </div>
-                                      <div
-                                        className="flex flex-1 items-center justify-center"
-                                        style={{
-                                          borderLeft: `1px solid #ffffff33`,
-                                        }}
-                                      >
-                                        <p className="text-xs text-white my-[6px] w-[80px] text-center">
-                                          {item.video}
-                                        </p>
-                                      </div>
-                                    </div>
-                                  );
-                                })}
-                              </div>
-                            </div>
-                          </div>
-                        </div>,
-                        document.body
-                      )}
-                    </Popover.Panel>
-                  </Transition>
-                </>
-              )}
-            </Popover>
-          </div>
-        </div>
-      )}
+      <CornerDisplayInfo
+        participantId={participantId}
+        isPresenting={isPresenting}
+        show={mouseOver}
+      />
+      <CornerDisplayStats
+        participantId={participantId}
+        isPresenting={isPresenting}
+      />
     </>
   );
 };
 
-export function ParticipantView({ participantId }) {
-  const {
-    displayName,
-    micStream,
-    webcamOn,
-    micOn,
-    isLocal,
-    mode,
-    isActiveSpeaker,
-  } = useParticipant(participantId);
-
+const ParticipantAudioPlayer = ({ participantId }) => {
+  const { micStream, micOn, isLocal } = useParticipant(participantId);
   const { selectedSpeaker } = useMeetingAppContext();
   const micRef = useRef(null);
-  const [mouseOver, setMouseOver] = useState(false);
 
   useEffect(() => {
     const isFirefox =
@@ -451,10 +459,43 @@ export function ParticipantView({ participantId }) {
         micRef.current.srcObject = null;
       }
     }
-  }, [micStream, micOn, micRef])
+  }, [micStream, micOn]);
 
+  return <audio ref={micRef} autoPlay muted={isLocal} />;
+};
 
-  return mode === "SEND_AND_RECV" ? (
+const ParticipantVideoSection = ({ participantId }) => {
+  const { webcamOn, displayName } = useParticipant(participantId);
+
+  return webcamOn ? (
+    <VideoPlayer
+      participantId={participantId}
+      type="video"
+      containerStyle={{
+        height: "100%",
+        width: "100%",
+      }}
+      className="h-full"
+      classNameVideo="h-full"
+      videoStyle={{}}
+    />
+  ) : (
+    <div className="h-full w-full flex items-center justify-center">
+      <div
+        className={`z-10 flex items-center justify-center rounded-full bg-gray-800 2xl:h-[92px] h-[52px] 2xl:w-[92px] w-[52px]`}
+      >
+        <p className="text-2xl text-white">
+          {String(displayName).charAt(0).toUpperCase()}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const ParticipantViewContent = ({ participantId }) => {
+  const [mouseOver, setMouseOver] = useState(false);
+
+  return (
     <div
       onMouseEnter={() => {
         setMouseOver(true);
@@ -464,42 +505,23 @@ export function ParticipantView({ participantId }) {
       }}
       className={`h-full w-full  bg-gray-750 relative overflow-hidden rounded-lg video-cover`}
     >
-      <audio ref={micRef} autoPlay muted={isLocal} />
-      {webcamOn ? (
-        <VideoPlayer
-          participantId={participantId} // Required
-          type="video" // "video" or "share"
-          containerStyle={{
-            height: "100%",
-            width: "100%",
-          }}
-          className="h-full"
-          classNameVideo="h-full"
-          videoStyle={{}}
-        />
-      ) : (
-        <div className="h-full w-full flex items-center justify-center">
-          <div
-            className={`z-10 flex items-center justify-center rounded-full bg-gray-800 2xl:h-[92px] h-[52px] 2xl:w-[92px] w-[52px]`}
-          >
-            <p className="text-2xl text-white">
-              {String(displayName).charAt(0).toUpperCase()}
-            </p>
-          </div>
-        </div>
-      )}
+      <ParticipantAudioPlayer participantId={participantId} />
+      <ParticipantVideoSection participantId={participantId} />
       <CornerDisplayName
         {...{
-          isLocal,
-          displayName,
-          micOn,
-          webcamOn,
           isPresenting: false,
           participantId,
           mouseOver,
-          isActiveSpeaker,
         }}
       />
     </div>
+  );
+};
+
+export function ParticipantView({ participantId }) {
+  const { mode } = useParticipant(participantId);
+
+  return mode === "SEND_AND_RECV" ? (
+    <ParticipantViewContent participantId={participantId} />
   ) : null;
 }

--- a/src/components/PresenterView.js
+++ b/src/components/PresenterView.js
@@ -39,7 +39,45 @@ const PresenterAudioPlayer = ({ presenterId }) => {
   return <audio autoPlay playsInline controls={false} ref={audioPlayer} />;
 };
 
-const PresenterContent = ({ presenterId, toggleScreenShare }) => {
+const StopPresentingOverlay = ({ presenterId, toggleScreenShare }) => {
+  const { isLocal } = useParticipant(presenterId);
+
+  if (!isLocal) return null;
+
+  return (
+    <>
+      <div className="p-10 rounded-2xl flex flex-col items-center justify-center absolute top-1/2 left-1/2 bg-gray-750 transform -translate-x-1/2 -translate-y-1/2">
+        <ScreenShareIcon style={{ height: 48, width: 48, color: "white" }} />
+        <div className="mt-4">
+          <p className="text-white text-xl font-semibold">
+            You are presenting to everyone
+          </p>
+        </div>
+        <div className="mt-8">
+          <button
+            className="bg-purple-550 text-white px-4 py-2 rounded text-sm text-center font-medium"
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleScreenShare();
+            }}
+          >
+            STOP PRESENTING
+          </button>
+        </div>
+      </div>
+      <CornerDisplayName
+        {...{
+          participantId: presenterId,
+          isPresenting: true,
+          mouseOver: true,
+        }}
+      />
+    </>
+  );
+};
+
+
+const PresenterContent = ({ presenterId }) => {
   const { isLocal, micOn, displayName, isActiveSpeaker } =
     useParticipant(presenterId);
 
@@ -80,40 +118,6 @@ const PresenterContent = ({ presenterId, toggleScreenShare }) => {
             : `${nameTructed(displayName, 15)} is presenting`}
         </p>
       </div>
-      {isLocal ? (
-        <>
-          <div className="p-10 rounded-2xl flex flex-col items-center justify-center absolute top-1/2 left-1/2 bg-gray-750 transform -translate-x-1/2 -translate-y-1/2">
-            <ScreenShareIcon
-              style={{ height: 48, width: 48, color: "white" }}
-            />
-            <div className="mt-4">
-              <p className="text-white text-xl font-semibold">
-                You are presenting to everyone
-              </p>
-            </div>
-            <div className="mt-8">
-              <button
-                className="bg-purple-550 text-white px-4 py-2 rounded text-sm text-center font-medium"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleScreenShare();
-                }}
-              >
-                STOP PRESENTING
-              </button>
-            </div>
-          </div>
-          <CornerDisplayName
-            {...{
-              participantId: presenterId,
-              isPresenting: true,
-              mouseOver: true,
-            }}
-          />
-        </>
-      ) : (
-        <></>
-      )}
     </div>
   );
 };
@@ -127,7 +131,8 @@ export function PresenterView({ height }) {
         }] `}
     >
       <PresenterAudioPlayer presenterId={presenterId} />
-      <PresenterContent
+      <PresenterContent presenterId={presenterId} />
+      <StopPresentingOverlay
         presenterId={presenterId}
         toggleScreenShare={toggleScreenShare}
       />

--- a/src/components/PresenterView.js
+++ b/src/components/PresenterView.js
@@ -1,25 +1,14 @@
 import { useMeeting, useParticipant, VideoPlayer } from "@videosdk.live/react-sdk";
-import { useEffect, useMemo, useRef } from "react";
-import ReactPlayer from "react-player";
+import { useEffect, useRef } from "react";
 import MicOffSmallIcon from "../icons/MicOffSmallIcon";
 import ScreenShareIcon from "../icons/ScreenShareIcon";
 import SpeakerIcon from "../icons/SpeakerIcon";
 import { nameTructed } from "../utils/helper";
 import { CornerDisplayName } from "./ParticipantView";
 
-export function PresenterView({ height }) {
-  const mMeeting = useMeeting();
-  const presenterId = mMeeting?.presenterId;
-  const {
-    micOn,
-    webcamOn,
-    isLocal,
-    screenShareAudioStream,
-    screenShareOn,
-    displayName,
-    isActiveSpeaker,
-  } = useParticipant(presenterId);
-
+const PresenterAudioPlayer = ({ presenterId }) => {
+  const { isLocal, screenShareAudioStream, screenShareOn } =
+    useParticipant(presenterId);
 
   const audioPlayer = useRef();
 
@@ -47,88 +36,101 @@ export function PresenterView({ height }) {
     }
   }, [screenShareAudioStream, screenShareOn, isLocal]);
 
+  return <audio autoPlay playsInline controls={false} ref={audioPlayer} />;
+};
+
+const PresenterContent = ({ presenterId, toggleScreenShare }) => {
+  const { isLocal, micOn, displayName, isActiveSpeaker } =
+    useParticipant(presenterId);
+
+  return (
+    <div className={"video-contain absolute h-full w-full"}>
+      <VideoPlayer
+        participantId={presenterId}
+        type="share"
+        containerStyle={{
+          height: "100%",
+          width: "100%",
+        }}
+        className="h-full"
+        classNameVideo="h-full"
+        videoStyle={{
+          filter: isLocal ? "blur(1rem)" : undefined,
+        }}
+      />
+
+      <div
+        className="bottom-2 left-2 bg-gray-750 p-2 absolute rounded-md flex items-center justify-center"
+        style={{
+          transition: "all 200ms",
+          transitionTimingFunction: "linear",
+        }}
+      >
+        {!micOn ? (
+          <MicOffSmallIcon fillcolor="white" />
+        ) : micOn && isActiveSpeaker ? (
+          <SpeakerIcon />
+        ) : (
+          <></>
+        )}
+
+        <p className="text-sm text-white">
+          {isLocal
+            ? `You are presenting`
+            : `${nameTructed(displayName, 15)} is presenting`}
+        </p>
+      </div>
+      {isLocal ? (
+        <>
+          <div className="p-10 rounded-2xl flex flex-col items-center justify-center absolute top-1/2 left-1/2 bg-gray-750 transform -translate-x-1/2 -translate-y-1/2">
+            <ScreenShareIcon
+              style={{ height: 48, width: 48, color: "white" }}
+            />
+            <div className="mt-4">
+              <p className="text-white text-xl font-semibold">
+                You are presenting to everyone
+              </p>
+            </div>
+            <div className="mt-8">
+              <button
+                className="bg-purple-550 text-white px-4 py-2 rounded text-sm text-center font-medium"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleScreenShare();
+                }}
+              >
+                STOP PRESENTING
+              </button>
+            </div>
+          </div>
+          <CornerDisplayName
+            {...{
+              participantId: presenterId,
+              isPresenting: true,
+              mouseOver: true,
+            }}
+          />
+        </>
+      ) : (
+        <></>
+      )}
+    </div>
+  );
+};
+
+export function PresenterView({ height }) {
+  const { presenterId, toggleScreenShare } = useMeeting();
+
   return (
     <div
       className={` bg-gray-750 rounded m-2 relative overflow-hidden w-full h-[${height - "xl:p-6 lg:p-[52px] md:p-[26px] p-1"
         }] `}
     >
-      <audio autoPlay playsInline controls={false} ref={audioPlayer} />
-      <div className={"video-contain absolute h-full w-full"}>
-
-        <VideoPlayer
-          participantId={presenterId} // Required
-          type="share" // "video" or "share"
-          containerStyle={{
-            height: "100%",
-            width: "100%",
-          }}
-          className="h-full"
-          classNameVideo="h-full"
-          videoStyle={{
-            filter: isLocal ? "blur(1rem)" : undefined,
-          }}
-        />
-
-        <div
-          className="bottom-2 left-2 bg-gray-750 p-2 absolute rounded-md flex items-center justify-center"
-          style={{
-            transition: "all 200ms",
-            transitionTimingFunction: "linear",
-          }}
-        >
-          {!micOn ? (
-            <MicOffSmallIcon fillcolor="white" />
-          ) : micOn && isActiveSpeaker ? (
-            <SpeakerIcon />
-          ) : (
-            <></>
-          )}
-
-          <p className="text-sm text-white">
-            {isLocal
-              ? `You are presenting`
-              : `${nameTructed(displayName, 15)} is presenting`}
-          </p>
-        </div>
-        {isLocal ? (
-          <>
-            <div className="p-10 rounded-2xl flex flex-col items-center justify-center absolute top-1/2 left-1/2 bg-gray-750 transform -translate-x-1/2 -translate-y-1/2">
-              <ScreenShareIcon
-                style={{ height: 48, width: 48, color: "white" }}
-              />
-              <div className="mt-4">
-                <p className="text-white text-xl font-semibold">
-                  You are presenting to everyone
-                </p>
-              </div>
-              <div className="mt-8">
-                <button
-                  className="bg-purple-550 text-white px-4 py-2 rounded text-sm text-center font-medium"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    mMeeting.toggleScreenShare();
-                  }}
-                >
-                  STOP PRESENTING
-                </button>
-              </div>
-            </div>
-            <CornerDisplayName
-              {...{
-                isLocal,
-                displayName,
-                micOn,
-                webcamOn,
-                isPresenting: true,
-                participantId: presenterId,
-                isActiveSpeaker,
-              }}
-            />
-          </>
-        ) : (
-          <></>
-        )}
-      </div>
+      <PresenterAudioPlayer presenterId={presenterId} />
+      <PresenterContent
+        presenterId={presenterId}
+        toggleScreenShare={toggleScreenShare}
+      />
     </div>
   );
 }

--- a/src/components/sidebar/ChatPanel.js
+++ b/src/components/sidebar/ChatPanel.js
@@ -4,9 +4,7 @@ import { formatAMPM, json_verify, nameTructed } from "../../utils/helper";
 import { PaperAirplaneIcon } from "@heroicons/react/24/outline";
 
 
-const ChatMessage = ({ senderId, senderName, text, timestamp }) => {
-  const mMeeting = useMeeting();
-  const localParticipantId = mMeeting?.localParticipant?.id;
+const ChatMessage = ({ senderId, senderName, text, timestamp, localParticipantId }) => {
   const localSender = localParticipantId === senderId;
 
   return (
@@ -111,6 +109,8 @@ const ChatInput = ({ inputHeight }) => {
 
 const ChatMessages = ({ listHeight }) => {
   const listRef = useRef();
+  const { localParticipant } = useMeeting();
+  const localParticipantId = localParticipant?.id;
   const { messages } = usePubSub("CHAT");
 
   const scrollToBottom = (data) => {
@@ -144,7 +144,7 @@ const ChatMessages = ({ listHeight }) => {
           return (
             <ChatMessage
               key={`chat_item_${i}`}
-              {...{ senderId, senderName, text: message, timestamp }}
+              {...{ senderId, senderName, text: message, timestamp, localParticipantId }}
             />
           );
         })}

--- a/src/components/sidebar/ParticipantPanel.js
+++ b/src/components/sidebar/ParticipantPanel.js
@@ -8,9 +8,24 @@ import VideoCamOnIcon from "../../icons/ParticipantTabPanel/VideoCamOnIcon";
 import { useMeetingAppContext } from "../../MeetingAppContextDef";
 import { nameTructed } from "../../utils/helper";
 
+const ParticipantMicStatus = React.memo(({ participantId }) => {
+  const { micOn } = useParticipant(participantId);
+  return (
+    <div className="m-1 p-1">{micOn ? <MicOnIcon /> : <MicOffIcon />}</div>
+  );
+}, (prevProps, nextProps) => prevProps.participantId === nextProps.participantId);
+
+const ParticipantCamStatus = React.memo(({ participantId }) => {
+  const { webcamOn } = useParticipant(participantId);
+  return (
+    <div className="m-1 p-1">
+      {webcamOn ? <VideoCamOnIcon /> : <VideoCamOffIcon />}
+    </div>
+  );
+}, (prevProps, nextProps) => prevProps.participantId === nextProps.participantId);
+
 function ParticipantListItem({ participantId, raisedHand }) {
-  const { micOn, webcamOn, displayName, isLocal } =
-    useParticipant(participantId);
+  const { displayName, isLocal } = useParticipant(participantId);
 
   return (
     <div className="mt-2 m-2 p-2 bg-gray-700 rounded-lg mb-0">
@@ -34,10 +49,8 @@ function ParticipantListItem({ participantId, raisedHand }) {
             <RaiseHand fillcolor={"#fff"} />
           </div>
         )}
-        <div className="m-1 p-1">{micOn ? <MicOnIcon /> : <MicOffIcon />}</div>
-        <div className="m-1 p-1">
-          {webcamOn ? <VideoCamOnIcon /> : <VideoCamOffIcon />}
-        </div>
+        <ParticipantMicStatus participantId={participantId} />
+        <ParticipantCamStatus participantId={participantId} />
       </div>
     </div>
   );

--- a/src/components/sidebar/ParticipantPanel.js
+++ b/src/components/sidebar/ParticipantPanel.js
@@ -13,7 +13,7 @@ const ParticipantMicStatus = React.memo(({ participantId }) => {
   return (
     <div className="m-1 p-1">{micOn ? <MicOnIcon /> : <MicOffIcon />}</div>
   );
-}, (prevProps, nextProps) => prevProps.participantId === nextProps.participantId);
+});
 
 const ParticipantCamStatus = React.memo(({ participantId }) => {
   const { webcamOn } = useParticipant(participantId);
@@ -22,7 +22,7 @@ const ParticipantCamStatus = React.memo(({ participantId }) => {
       {webcamOn ? <VideoCamOnIcon /> : <VideoCamOffIcon />}
     </div>
   );
-}, (prevProps, nextProps) => prevProps.participantId === nextProps.participantId);
+});
 
 function ParticipantListItem({ participantId, raisedHand }) {
   const { displayName, isLocal } = useParticipant(participantId);

--- a/src/meeting/MeetingContainer.js
+++ b/src/meeting/MeetingContainer.js
@@ -13,6 +13,76 @@ import { useMediaQuery } from "react-responsive";
 import { toast } from "react-toastify";
 import { useMeetingAppContext } from "../MeetingAppContextDef";
 
+const ParticipantMicStream = memo(({ participantId }) => {
+  const { micStream, isLocal } = useParticipant(participantId);
+
+  useEffect(() => {
+    if (micStream) {
+      const mediaStream = new MediaStream();
+      mediaStream.addTrack(micStream.track);
+
+      const audioElement = new Audio();
+      audioElement.srcObject = mediaStream;
+      audioElement.muted = isLocal;
+      audioElement.play();
+    }
+  }, [micStream, participantId]);
+
+  return null;
+}, (prevProps, nextProps) => prevProps.participantId === nextProps.participantId);
+
+const MeetingContent = React.memo(({
+  containerHeight,
+  bottomBarHeight,
+  isMobile,
+  sideBarContainerWidth,
+}) => {
+  const { presenterId, participants } = useMeeting();
+  const isPresenting = presenterId ? true : false;
+
+  const [participantsData, setParticipantsData] = useState([]);
+
+  useEffect(() => {
+    const debounceTimeout = setTimeout(() => {
+      const participantIds = Array.from(participants.keys());
+      setParticipantsData(participantIds);
+    }, 500);
+
+    return () => clearTimeout(debounceTimeout);
+  }, [participants]);
+
+  return (
+    <>
+      <div className={` flex flex-1 flex-row bg-gray-800 `}>
+        <div className={`flex flex-1 `}>
+          {isPresenting ? (
+            <PresenterView height={containerHeight - bottomBarHeight} />
+          ) : null}
+          {isPresenting && isMobile ? (
+            participantsData.map((participantId) => (
+              <ParticipantMicStream key={participantId} participantId={participantId} />
+            ))
+          ) : (
+            <MemorizedParticipantView isPresenting={isPresenting} />
+          )}
+        </div>
+
+        <SidebarConatiner
+          height={containerHeight - bottomBarHeight}
+          sideBarContainerWidth={sideBarContainerWidth}
+        />
+      </div>
+    </>
+  );
+}, (prevProps, nextProps) => {
+  return (
+    prevProps.containerHeight === nextProps.containerHeight &&
+    prevProps.bottomBarHeight === nextProps.bottomBarHeight &&
+    prevProps.isMobile === nextProps.isMobile &&
+    prevProps.sideBarContainerWidth === nextProps.sideBarContainerWidth
+  );
+});
+
 export function MeetingContainer({
   onMeetingLeave,
   setIsMeetingLeft,
@@ -23,31 +93,9 @@ export function MeetingContainer({
     setSelectedSpeaker,
   } = useMeetingAppContext();
 
-  const [participantsData, setParticipantsData] = useState([]);
-
-  const ParticipantMicStream = memo(({ participantId }) => {
-    // Individual hook for each participant
-    const { micStream, isLocal } = useParticipant(participantId);
-
-    useEffect(() => {
-
-      if (micStream) {
-        const mediaStream = new MediaStream();
-        mediaStream.addTrack(micStream.track);
-
-        const audioElement = new Audio();
-        audioElement.srcObject = mediaStream;
-        audioElement.muted = isLocal
-        audioElement.play();
-
-      }
-    }, [micStream, participantId]);
-
-    return null;
-  }, [participantsData]);
-
   const { useRaisedHandParticipants } = useMeetingAppContext();
   const bottomBarHeight = 60;
+  const localParticipantRef = useRef();
 
   const [containerHeight, setContainerHeight] = useState(0);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -55,7 +103,6 @@ export function MeetingContainer({
   const [meetingErrorVisible, setMeetingErrorVisible] = useState(false);
   const [meetingError, setMeetingError] = useState(false);
 
-  const mMeetingRef = useRef();
   const containerRef = createRef();
   const containerHeightRef = useRef();
   const containerWidthRef = useRef();
@@ -125,13 +172,12 @@ export function MeetingContainer({
   };
 
   function onParticipantJoined(participant) {
-    // Change quality to low, med or high based on resolution
     participant && participant.setQuality("high");
   }
 
 
   function onEntryResponded(participantId, name) {
-    if (mMeetingRef.current?.localParticipant?.id === participantId) {
+    if (localParticipantRef.current?.id === participantId) {
       if (name === "allowed") {
         setLocalParticipantAllowedJoin(true);
       } else {
@@ -144,7 +190,6 @@ export function MeetingContainer({
   }
 
   function onMeetingJoined() {
-    console.log("onMeetingJoined");
   }
 
   function onMeetingLeft() {
@@ -156,7 +201,6 @@ export function MeetingContainer({
 
   const _handleOnError = (data) => {
     const { code, message } = data;
-    console.log("meetingErr", code, message)
 
     const joiningErrCodes = [
       4001, 4002, 4003, 4004, 4005, 4006, 4007, 4008, 4009, 4010,
@@ -178,7 +222,7 @@ export function MeetingContainer({
     });
   };
 
-  const mMeeting = useMeeting({
+  const { isMeetingJoined, localParticipant } = useMeeting({
     onParticipantJoined,
     onEntryResponded,
     onMeetingJoined,
@@ -199,30 +243,13 @@ export function MeetingContainer({
     onRecordingStateChanged: _handleOnRecordingStateChanged,
   });
 
-  const isPresenting = mMeeting.presenterId ? true : false;
-
   useEffect(() => {
-    const debounceTimeout = setTimeout(() => {
-      const participantIds = Array.from(mMeeting.participants.keys());
-      console.log("Debounced participantIds", participantIds);
-
-      setParticipantsData(participantIds);
-      console.log("Setting participants");
-    }, 500);
-
-
-    return () => clearTimeout(debounceTimeout);
-  }, [mMeeting.participants]);
-
-
-  useEffect(() => {
-    mMeetingRef.current = mMeeting;
-  }, [mMeeting]);
-
+    localParticipantRef.current = localParticipant;
+  }, [localParticipant]);
 
   usePubSub("RAISE_HAND", {
     onMessageReceived: (data) => {
-      const localParticipantId = mMeeting?.localParticipant?.id;
+      const localParticipantId = localParticipantRef.current?.id;
 
       const { senderId, senderName } = data;
 
@@ -249,7 +276,7 @@ export function MeetingContainer({
 
   usePubSub("CHAT", {
     onMessageReceived: (data) => {
-      const localParticipantId = mMeeting?.localParticipant?.id;
+      const localParticipantId = localParticipantRef.current?.id;
 
       const { senderId, senderName, message } = data;
 
@@ -285,25 +312,12 @@ export function MeetingContainer({
         {typeof localParticipantAllowedJoin === "boolean" ? (
           localParticipantAllowedJoin ? (
             <>
-              <div className={` flex flex-1 flex-row bg-gray-800 `}>
-                <div className={`flex flex-1 `}>
-                  {isPresenting ? (
-                    <PresenterView height={containerHeight - bottomBarHeight} />
-                  ) : null}
-                  {isPresenting && isMobile ? (
-                    participantsData.map((participantId) => (
-                      <ParticipantMicStream key={participantId} participantId={participantId} />
-                    ))
-                  ) : (
-                    <MemorizedParticipantView isPresenting={isPresenting} />
-                  )}
-                </div>
-
-                <SidebarConatiner
-                  height={containerHeight - bottomBarHeight}
-                  sideBarContainerWidth={sideBarContainerWidth}
-                />
-              </div>
+              <MeetingContent
+                containerHeight={containerHeight}
+                bottomBarHeight={bottomBarHeight}
+                isMobile={isMobile}
+                sideBarContainerWidth={sideBarContainerWidth}
+              />
 
               <BottomBar
                 bottomBarHeight={bottomBarHeight}
@@ -314,7 +328,7 @@ export function MeetingContainer({
             <></>
           )
         ) : (
-          !mMeeting.isMeetingJoined && <WaitingToJoinScreen />
+          !isMeetingJoined && <WaitingToJoinScreen />
         )}
         <ConfirmBox
           open={meetingErrorVisible}

--- a/src/meeting/MeetingContainer.js
+++ b/src/meeting/MeetingContainer.js
@@ -17,19 +17,24 @@ const ParticipantMicStream = memo(({ participantId }) => {
   const { micStream, isLocal } = useParticipant(participantId);
 
   useEffect(() => {
-    if (micStream) {
-      const mediaStream = new MediaStream();
-      mediaStream.addTrack(micStream.track);
+    if (!micStream) return;
 
-      const audioElement = new Audio();
-      audioElement.srcObject = mediaStream;
-      audioElement.muted = isLocal;
-      audioElement.play();
-    }
-  }, [micStream, participantId]);
+    const mediaStream = new MediaStream();
+    mediaStream.addTrack(micStream.track);
+
+    const audioElement = new Audio();
+    audioElement.srcObject = mediaStream;
+    audioElement.muted = isLocal;
+    audioElement.play().catch(() => {});
+
+    return () => {
+      audioElement.pause();
+      audioElement.srcObject = null;
+    };
+  }, [micStream, isLocal, participantId]);
 
   return null;
-}, (prevProps, nextProps) => prevProps.participantId === nextProps.participantId);
+});
 
 const MeetingContent = React.memo(({
   containerHeight,
@@ -73,13 +78,6 @@ const MeetingContent = React.memo(({
         />
       </div>
     </>
-  );
-}, (prevProps, nextProps) => {
-  return (
-    prevProps.containerHeight === nextProps.containerHeight &&
-    prevProps.bottomBarHeight === nextProps.bottomBarHeight &&
-    prevProps.isMobile === nextProps.isMobile &&
-    prevProps.sideBarContainerWidth === nextProps.sideBarContainerWidth
   );
 });
 
@@ -189,9 +187,6 @@ export function MeetingContainer({
     }
   }
 
-  function onMeetingJoined() {
-  }
-
   function onMeetingLeft() {
     setSelectedMic({ id: null, label: null })
     setSelectedWebcam({ id: null, label: null })
@@ -225,7 +220,6 @@ export function MeetingContainer({
   const { isMeetingJoined, localParticipant } = useMeeting({
     onParticipantJoined,
     onEntryResponded,
-    onMeetingJoined,
     onMeetingStateChanged: ({state}) => {
       toast(`Meeting is in ${state} state`, {
         position: "bottom-left",

--- a/src/meeting/components/BottomBar.js
+++ b/src/meeting/components/BottomBar.js
@@ -219,6 +219,9 @@ const MicBTN = () => {
                   <>
                     <Popover.Button
                       disabled={!isMicrophonePermissionAllowed}
+                      onClick={() => {
+                        getMics();
+                      }}
                       className="flex items-center justify-center mt-1 mr-1 focus:outline-none"
                     >
                       <div
@@ -226,18 +229,12 @@ const MicBTN = () => {
                         onMouseEnter={openTooltip}
                         onMouseLeave={closeTooltip}
                       >
-                        <button
-                          onClick={() => {
-                            getMics();
+                        <ChevronDownIcon
+                          className="h-4 w-4"
+                          style={{
+                            color: localMicOn ? "white" : "black",
                           }}
-                        >
-                          <ChevronDownIcon
-                            className="h-4 w-4"
-                            style={{
-                              color: localMicOn ? "white" : "black",
-                            }}
-                          />
-                        </button>
+                        />
                       </div>
                     </Popover.Button>
                     <Transition
@@ -391,6 +388,9 @@ const WebCamBTN = () => {
                   <>
                     <Popover.Button
                       disabled={!isCameraPermissionAllowed}
+                      onClick={() => {
+                        getWebcams();
+                      }}
                       className="flex items-center justify-center mt-1 mr-1 focus:outline-none"
                     >
                       <div
@@ -398,18 +398,12 @@ const WebCamBTN = () => {
                         onMouseEnter={openTooltip}
                         onMouseLeave={closeTooltip}
                       >
-                        <button
-                          onClick={() => {
-                            getWebcams();
+                        <ChevronDownIcon
+                          className="h-4 w-4"
+                          style={{
+                            color: localWebcamOn ? "white" : "black",
                           }}
-                        >
-                          <ChevronDownIcon
-                            className="h-4 w-4"
-                            style={{
-                              color: localWebcamOn ? "white" : "black",
-                            }}
-                          />
-                        </button>
+                        />
                       </div>
                     </Popover.Button>
                     <Transition

--- a/src/meeting/components/BottomBar.js
+++ b/src/meeting/components/BottomBar.js
@@ -162,29 +162,20 @@ const MicBTN = () => {
     isMicrophonePermissionAllowed,
   } = useMeetingAppContext();
 
-  const { getMicrophones, getPlaybackDevices } = useMediaDevice();
+  const { getMicrophones, getPlaybackDevices } = useMediaDevice({
+    onDeviceChanged(devices) {
+      getMics();
+      const newSpeakerList = devices.devices.filter(device => device.kind === 'audiooutput');
 
-  const mMeeting = useMeeting();
+      if (newSpeakerList.length > 0) {
+        setSelectedSpeaker({ id: newSpeakerList[0].deviceId, label: newSpeakerList[0].label });
+      }
+    }
+  });
+
+  const { localMicOn, changeMic, toggleMic } = useMeeting();
   const [mics, setMics] = useState([]);
   const [speakers, setSpeakers] = useState([]);
-  const localMicOn = mMeeting?.localMicOn;
-  const changeMic = mMeeting?.changeMic;
-
-  useMediaDevice({
-    onDeviceChanged
-  })
-
-  function onDeviceChanged(devices) {
-    getMics();
-    const newSpeakerList = devices.devices.filter(device => device.kind === 'audiooutput');
-
-    if (newSpeakerList.length > 0) {
-      setSelectedSpeaker({ id: newSpeakerList[0].deviceId, label: newSpeakerList[0].label });
-    }
-
-  }
-
-
 
   const getMics = async () => {
     const mics = await getMicrophones();
@@ -213,7 +204,7 @@ const MicBTN = () => {
       <OutlinedButton
         Icon={localMicOn ? MicOnIcon : MicOffIcon}
         onClick={() => {
-          mMeeting.toggleMic();
+          toggleMic();
         }}
         bgColor={localMicOn ? "bg-gray-750" : "bg-white"}
         borderColor={localMicOn && "#ffffff33"}
@@ -243,7 +234,7 @@ const MicBTN = () => {
                           <ChevronDownIcon
                             className="h-4 w-4"
                             style={{
-                              color: mMeeting.localMicOn ? "white" : "black",
+                              color: localMicOn ? "white" : "black",
                             }}
                           />
                         </button>
@@ -351,12 +342,9 @@ const WebCamBTN = () => {
     useMeetingAppContext();
 
   const { getCameras } = useMediaDevice();
-  const mMeeting = useMeeting();
+  const { localWebcamOn, changeWebcam, toggleWebcam } = useMeeting();
   const [webcams, setWebcams] = useState([]);
   const { getVideoTrack } = useMediaStream();
-
-  const localWebcamOn = mMeeting?.localWebcamOn;
-  const changeWebcam = mMeeting?.changeWebcam;
 
   const getWebcams = async () => {
     let webcams = await getCameras();
@@ -388,7 +376,7 @@ const WebCamBTN = () => {
               webcamId: selectedWebcam.id,
             });
           }
-          mMeeting.toggleWebcam(track);
+          toggleWebcam(track);
         }}
         bgColor={localWebcamOn ? "bg-gray-750" : "bg-white"}
         borderColor={localWebcamOn && "#ffffff33"}
@@ -491,252 +479,255 @@ const WebCamBTN = () => {
   );
 };
 
-export function BottomBar({ bottomBarHeight, setIsMeetingLeft }) {
+const RaiseHandBTN = ({ isMobile, isTab }) => {
+  const { publish } = usePubSub("RAISE_HAND");
+  const RaiseHand = () => {
+    try {
+      publish("Raise Hand");
+    } catch (e) {
+      console.log("Error in pubsub", e)
+    }
+  };
+
+  return isMobile || isTab ? (
+    <MobileIconButton
+      id="RaiseHandBTN"
+      tooltipTitle={"Raise hand"}
+      Icon={RaiseHandIcon}
+      onClick={RaiseHand}
+      buttonText={"Raise Hand"}
+    />
+  ) : (
+    <OutlinedButton
+      onClick={RaiseHand}
+      tooltip={"Raise Hand"}
+      Icon={RaiseHandIcon}
+    />
+  );
+};
+
+const RecordingBTN = () => {
+  const { startRecording, stopRecording, recordingState } = useMeeting();
+  const defaultOptions = {
+    loop: true,
+    autoplay: true,
+    animationData: recordingBlink,
+    rendererSettings: {
+      preserveAspectRatio: "xMidYMid slice",
+    },
+    height: 64,
+    width: 160,
+  };
+
+  const isRecording = useIsRecording();
+  const isRecordingRef = useRef(isRecording);
+
+  useEffect(() => {
+    isRecordingRef.current = isRecording;
+  }, [isRecording]);
+
+  const { isRequestProcessing } = useMemo(
+    () => ({
+      isRequestProcessing:
+        recordingState === Constants.recordingEvents.RECORDING_STARTING ||
+        recordingState === Constants.recordingEvents.RECORDING_STOPPING,
+    }),
+    [recordingState]
+  );
+
+  const _handleClick = () => {
+    const isRecording = isRecordingRef.current;
+
+    if (isRecording) {
+      stopRecording();
+    } else {
+      startRecording();
+    }
+  };
+
+  return (
+    <OutlinedButton
+      Icon={RecordingIcon}
+      onClick={_handleClick}
+      isFocused={isRecording}
+      tooltip={
+        recordingState === Constants.recordingEvents.RECORDING_STARTED
+          ? "Stop Recording"
+          : recordingState === Constants.recordingEvents.RECORDING_STARTING
+            ? "Starting Recording"
+            : recordingState === Constants.recordingEvents.RECORDING_STOPPED
+              ? "Start Recording"
+              : recordingState === Constants.recordingEvents.RECORDING_STOPPING
+                ? "Stopping Recording"
+                : "Start Recording"
+      }
+      lottieOption={isRecording ? defaultOptions : null}
+      isRequestProcessing={isRequestProcessing}
+    />
+  );
+};
+
+const ScreenShareBTN = ({ isMobile, isTab }) => {
+  const { localScreenShareOn, toggleScreenShare, presenterId } = useMeeting();
+
+  return isMobile || isTab ? (
+    <MobileIconButton
+      id="screen-share-btn"
+      tooltipTitle={
+        presenterId
+          ? localScreenShareOn
+            ? "Stop Presenting"
+            : null
+          : "Present Screen"
+      }
+      buttonText={
+        presenterId
+          ? localScreenShareOn
+            ? "Stop Presenting"
+            : null
+          : "Present Screen"
+      }
+      isFocused={localScreenShareOn}
+      Icon={ScreenShareIcon}
+      onClick={() => {
+        toggleScreenShare();
+      }}
+      disabled={
+        presenterId
+          ? localScreenShareOn
+            ? false
+            : true
+          : isMobile
+            ? true
+            : false
+      }
+    />
+  ) : (
+    <OutlinedButton
+      Icon={ScreenShareIcon}
+      onClick={() => {
+        toggleScreenShare();
+      }}
+      isFocused={localScreenShareOn}
+      tooltip={
+        presenterId
+          ? localScreenShareOn
+            ? "Stop Presenting"
+            : null
+          : "Present Screen"
+      }
+      disabled={presenterId ? (localScreenShareOn ? false : true) : false}
+    />
+  );
+};
+
+const LeaveBTN = ({ setIsMeetingLeft }) => {
+  const { leave } = useMeeting();
+
+  return (
+    <OutlinedButton
+      Icon={EndIcon}
+      bgColor="bg-red-150"
+      onClick={() => {
+        leave();
+        setIsMeetingLeft(true);
+      }}
+      tooltip="Leave Meeting"
+    />
+  );
+};
+
+const ChatBTN = ({ isMobile, isTab }) => {
   const { sideBarMode, setSideBarMode } = useMeetingAppContext();
-  const RaiseHandBTN = ({ isMobile, isTab }) => {
-    const { publish } = usePubSub("RAISE_HAND");
-    const RaiseHand = () => {
-      try {
-        publish("Raise Hand");
-      } catch (e) {
-        console.log("Error in pubsub", e)
-      }
-    };
 
-    return isMobile || isTab ? (
-      <MobileIconButton
-        id="RaiseHandBTN"
-        tooltipTitle={"Raise hand"}
-        Icon={RaiseHandIcon}
-        onClick={RaiseHand}
-        buttonText={"Raise Hand"}
-      />
-    ) : (
-      <OutlinedButton
-        onClick={RaiseHand}
-        tooltip={"Raise Hand"}
-        Icon={RaiseHandIcon}
-      />
-    );
-  };
+  return isMobile || isTab ? (
+    <MobileIconButton
+      tooltipTitle={"Chat"}
+      buttonText={"Chat"}
+      Icon={ChatIcon}
+      isFocused={sideBarMode === sideBarModes.CHAT}
+      onClick={() => {
+        setSideBarMode((s) =>
+          s === sideBarModes.CHAT ? null : sideBarModes.CHAT
+        );
+      }}
+    />
+  ) : (
+    <OutlinedButton
+      Icon={ChatIcon}
+      onClick={() => {
+        setSideBarMode((s) =>
+          s === sideBarModes.CHAT ? null : sideBarModes.CHAT
+        );
+      }}
+      isFocused={sideBarMode === "CHAT"}
+      tooltip="View Chat"
+    />
+  );
+};
 
-  const RecordingBTN = () => {
-    const { startRecording, stopRecording, recordingState } = useMeeting();
-    const defaultOptions = {
-      loop: true,
-      autoplay: true,
-      animationData: recordingBlink,
-      rendererSettings: {
-        preserveAspectRatio: "xMidYMid slice",
-      },
-      height: 64,
-      width: 160,
-    };
+const ParticipantsBTN = ({ isMobile, isTab }) => {
+  const { participants } = useMeeting();
+  const { sideBarMode, setSideBarMode } = useMeetingAppContext();
 
-    const isRecording = useIsRecording();
-    const isRecordingRef = useRef(isRecording);
+  return isMobile || isTab ? (
+    <MobileIconButton
+      tooltipTitle={"Participants"}
+      isFocused={sideBarMode === sideBarModes.PARTICIPANTS}
+      buttonText={"Participants"}
+      disabledOpacity={1}
+      Icon={ParticipantsIcon}
+      onClick={() => {
+        setSideBarMode((s) =>
+          s === sideBarModes.PARTICIPANTS ? null : sideBarModes.PARTICIPANTS
+        );
+      }}
+      badge={`${new Map(participants)?.size}`}
+    />
+  ) : (
+    <OutlinedButton
+      Icon={ParticipantsIcon}
+      onClick={() => {
+        setSideBarMode((s) =>
+          s === sideBarModes.PARTICIPANTS ? null : sideBarModes.PARTICIPANTS
+        );
+      }}
+      isFocused={sideBarMode === sideBarModes.PARTICIPANTS}
+      tooltip={"View \nParticipants"}
+      badge={`${new Map(participants)?.size}`}
+    />
+  );
+};
 
-    useEffect(() => {
-      isRecordingRef.current = isRecording;
-    }, [isRecording]);
-
-    const { isRequestProcessing } = useMemo(
-      () => ({
-        isRequestProcessing:
-          recordingState === Constants.recordingEvents.RECORDING_STARTING ||
-          recordingState === Constants.recordingEvents.RECORDING_STOPPING,
-      }),
-      [recordingState]
-    );
-
-    const _handleClick = () => {
-      const isRecording = isRecordingRef.current;
-
-      if (isRecording) {
-        stopRecording();
-      } else {
-        startRecording();
-      }
-    };
-
-    return (
-      <OutlinedButton
-        Icon={RecordingIcon}
-        onClick={_handleClick}
-        isFocused={isRecording}
-        tooltip={
-          recordingState === Constants.recordingEvents.RECORDING_STARTED
-            ? "Stop Recording"
-            : recordingState === Constants.recordingEvents.RECORDING_STARTING
-              ? "Starting Recording"
-              : recordingState === Constants.recordingEvents.RECORDING_STOPPED
-                ? "Start Recording"
-                : recordingState === Constants.recordingEvents.RECORDING_STOPPING
-                  ? "Stopping Recording"
-                  : "Start Recording"
-        }
-        lottieOption={isRecording ? defaultOptions : null}
-        isRequestProcessing={isRequestProcessing}
-      />
-    );
-  };
-
-  const ScreenShareBTN = ({ isMobile, isTab }) => {
-    const { localScreenShareOn, toggleScreenShare, presenterId } = useMeeting();
-
-    return isMobile || isTab ? (
-      <MobileIconButton
-        id="screen-share-btn"
-        tooltipTitle={
-          presenterId
-            ? localScreenShareOn
-              ? "Stop Presenting"
-              : null
-            : "Present Screen"
-        }
-        buttonText={
-          presenterId
-            ? localScreenShareOn
-              ? "Stop Presenting"
-              : null
-            : "Present Screen"
-        }
-        isFocused={localScreenShareOn}
-        Icon={ScreenShareIcon}
-        onClick={() => {
-          toggleScreenShare();
-        }}
-        disabled={
-          presenterId
-            ? localScreenShareOn
-              ? false
-              : true
-            : isMobile
-              ? true
-              : false
-        }
-      />
-    ) : (
-      <OutlinedButton
-        Icon={ScreenShareIcon}
-        onClick={() => {
-          toggleScreenShare();
-        }}
-        isFocused={localScreenShareOn}
-        tooltip={
-          presenterId
-            ? localScreenShareOn
-              ? "Stop Presenting"
-              : null
-            : "Present Screen"
-        }
-        disabled={presenterId ? (localScreenShareOn ? false : true) : false}
-      />
-    );
-  };
-
-  const LeaveBTN = () => {
-    const { leave } = useMeeting();
-
-    return (
-      <OutlinedButton
-        Icon={EndIcon}
-        bgColor="bg-red-150"
-        onClick={() => {
-          leave();
-          setIsMeetingLeft(true);
-        }}
-        tooltip="Leave Meeting"
-      />
-    );
-  };
-
-  const ChatBTN = ({ isMobile, isTab }) => {
-    return isMobile || isTab ? (
-      <MobileIconButton
-        tooltipTitle={"Chat"}
-        buttonText={"Chat"}
-        Icon={ChatIcon}
-        isFocused={sideBarMode === sideBarModes.CHAT}
-        onClick={() => {
-          setSideBarMode((s) =>
-            s === sideBarModes.CHAT ? null : sideBarModes.CHAT
-          );
-        }}
-      />
-    ) : (
-      <OutlinedButton
-        Icon={ChatIcon}
-        onClick={() => {
-          setSideBarMode((s) =>
-            s === sideBarModes.CHAT ? null : sideBarModes.CHAT
-          );
-        }}
-        isFocused={sideBarMode === "CHAT"}
-        tooltip="View Chat"
-      />
-    );
-  };
-
-  const ParticipantsBTN = ({ isMobile, isTab }) => {
-    const { participants } = useMeeting();
-    return isMobile || isTab ? (
-      <MobileIconButton
-        tooltipTitle={"Participants"}
-        isFocused={sideBarMode === sideBarModes.PARTICIPANTS}
-        buttonText={"Participants"}
-        disabledOpacity={1}
-        Icon={ParticipantsIcon}
-        onClick={() => {
-          setSideBarMode((s) =>
-            s === sideBarModes.PARTICIPANTS ? null : sideBarModes.PARTICIPANTS
-          );
-        }}
-        badge={`${new Map(participants)?.size}`}
-      />
-    ) : (
-      <OutlinedButton
-        Icon={ParticipantsIcon}
-        onClick={() => {
-          setSideBarMode((s) =>
-            s === sideBarModes.PARTICIPANTS ? null : sideBarModes.PARTICIPANTS
-          );
-        }}
-        isFocused={sideBarMode === sideBarModes.PARTICIPANTS}
-        tooltip={"View \nParticipants"}
-        badge={`${new Map(participants)?.size}`}
-      />
-    );
-  };
-
-  const MeetingIdCopyBTN = () => {
-    const { meetingId } = useMeeting();
-    const [isCopied, setIsCopied] = useState(false);
-    return (
-      <div className="flex items-center justify-center lg:ml-0 ml-4 mt-4 xl:mt-0">
-        <div className="flex border-2 border-gray-850 p-2 rounded-md items-center justify-center">
-          <h1 className="text-white text-base ">{meetingId}</h1>
-          <button
-            className="ml-2"
-            onClick={() => {
-              navigator.clipboard.writeText(meetingId);
-              setIsCopied(true);
-              setTimeout(() => {
-                setIsCopied(false);
-              }, 3000);
-            }}
-          >
-            {isCopied ? (
-              <CheckIcon className="h-5 w-5 text-green-400" />
-            ) : (
-              <ClipboardIcon className="h-5 w-5 text-white" />
-            )}
-          </button>
-        </div>
+const MeetingIdCopyBTN = () => {
+  const { meetingId } = useMeeting();
+  const [isCopied, setIsCopied] = useState(false);
+  return (
+    <div className="flex items-center justify-center lg:ml-0 ml-4 mt-4 xl:mt-0">
+      <div className="flex border-2 border-gray-850 p-2 rounded-md items-center justify-center">
+        <h1 className="text-white text-base ">{meetingId}</h1>
+        <button
+          className="ml-2"
+          onClick={() => {
+            navigator.clipboard.writeText(meetingId);
+            setIsCopied(true);
+            setTimeout(() => {
+              setIsCopied(false);
+            }, 3000);
+          }}
+        >
+          {isCopied ? (
+            <CheckIcon className="h-5 w-5 text-green-400" />
+          ) : (
+            <ClipboardIcon className="h-5 w-5 text-white" />
+          )}
+        </button>
       </div>
-    );
-  };
+    </div>
+  );
+};
 
+export function BottomBar({ bottomBarHeight, setIsMeetingLeft }) {
   const tollTipEl = useRef();
   const isMobile = useIsMobile();
   const isTab = useIsTab();
@@ -780,7 +771,7 @@ export function BottomBar({ bottomBarHeight, setIsMeetingLeft }) {
       className="flex items-center justify-center"
       style={{ height: bottomBarHeight }}
     >
-      <LeaveBTN />
+      <LeaveBTN setIsMeetingLeft={setIsMeetingLeft} />
       <MicBTN />
       <WebCamBTN />
       <RecordingBTN />
@@ -872,7 +863,7 @@ export function BottomBar({ bottomBarHeight, setIsMeetingLeft }) {
         <WebCamBTN />
         <ScreenShareBTN isMobile={isMobile} isTab={isTab} />
         <PipBTN isMobile={isMobile} isTab={isTab} />
-        <LeaveBTN />
+        <LeaveBTN setIsMeetingLeft={setIsMeetingLeft} />
       </div>
       <div className="flex items-center justify-center">
         <ChatBTN isMobile={isMobile} isTab={isTab} />

--- a/src/meeting/components/ParticipantView.js
+++ b/src/meeting/components/ParticipantView.js
@@ -2,17 +2,44 @@ import React, { useMemo } from "react";
 import { useMeeting } from "@videosdk.live/react-sdk";
 import { MemoizedParticipantGrid } from "../../components/ParticipantGrid";
 
+const ActiveSpeakerAwareGrid = React.memo(
+  ({ baseParticipantIds, isPresenting }) => {
+    const { activeSpeakerId } = useMeeting();
+
+    const participantIds = useMemo(() => {
+      const ids = [...baseParticipantIds];
+      if (activeSpeakerId) {
+        if (!ids.includes(activeSpeakerId)) {
+          ids[ids.length - 1] = activeSpeakerId;
+        }
+      }
+      return ids;
+    }, [baseParticipantIds, activeSpeakerId]);
+
+    return (
+      <MemoizedParticipantGrid
+        participantIds={participantIds}
+        isPresenting={isPresenting}
+      />
+    );
+  },
+  (prevProps, nextProps) => {
+    return (
+      JSON.stringify(prevProps.baseParticipantIds) ===
+        JSON.stringify(nextProps.baseParticipantIds) &&
+      prevProps.isPresenting === nextProps.isPresenting
+    );
+  }
+);
+
 function ParticipantsViewer({ isPresenting }) {
   const {
     participants,
     pinnedParticipants,
-    activeSpeakerId,
     localParticipant,
-    localScreenShareOn,
-    presenterId,
   } = useMeeting();
 
-  const participantIds = useMemo(() => {
+  const baseParticipantIds = useMemo(() => {
     const pinnedParticipantId = [...pinnedParticipants.keys()].filter(
       (participantId) => {
         return participantId !== localParticipant.id;
@@ -33,23 +60,12 @@ function ParticipantsViewer({ isPresenting }) {
       ...regularParticipantIds,
     ].slice(0, isPresenting ? 6 : 16);
 
-    if (activeSpeakerId) {
-      if (!ids.includes(activeSpeakerId)) {
-        ids[ids.length - 1] = activeSpeakerId;
-      }
-    }
     return ids;
-  }, [
-    participants,
-    activeSpeakerId,
-    pinnedParticipants,
-    presenterId,
-    localScreenShareOn,
-  ]);
+  }, [participants, pinnedParticipants, isPresenting]);
 
   return (
-    <MemoizedParticipantGrid
-      participantIds={participantIds}
+    <ActiveSpeakerAwareGrid
+      baseParticipantIds={baseParticipantIds}
       isPresenting={isPresenting}
     />
   );

--- a/src/meeting/components/ParticipantView.js
+++ b/src/meeting/components/ParticipantView.js
@@ -24,10 +24,14 @@ const ActiveSpeakerAwareGrid = React.memo(
     );
   },
   (prevProps, nextProps) => {
-    return (
-      JSON.stringify(prevProps.baseParticipantIds) ===
-        JSON.stringify(nextProps.baseParticipantIds) &&
-      prevProps.isPresenting === nextProps.isPresenting
+    if (prevProps.isPresenting !== nextProps.isPresenting) return false;
+    if (
+      prevProps.baseParticipantIds.length !== nextProps.baseParticipantIds.length
+    ) {
+      return false;
+    }
+    return prevProps.baseParticipantIds.every(
+      (id, i) => id === nextProps.baseParticipantIds[i]
     );
   }
 );


### PR DESCRIPTION
- **Split participant tile into smaller components** : Each part (audio, video, info) uses its own `useParticipant` with only required state, keeping the parent hook-free.
- **Cleaned up meeting structure** : Moved components to module level and extracted child components to avoid re-renders.
- **Applied the same pattern across UI** : Broke sidebar and presenter views into smaller components with isolated subscriptions.